### PR TITLE
fix: Xdebug compatibility with php 7.3

### DIFF
--- a/docker/PHP.Dockerfile
+++ b/docker/PHP.Dockerfile
@@ -11,4 +11,4 @@ RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli
 #     && docker-php-ext-configure gd --with-freetype --with-jpeg \
 #     && docker-php-ext-install -j$(nproc) gd
 
-RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN pecl install xdebug-2.7.0 && docker-php-ext-enable xdebug


### PR DESCRIPTION
Error: pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.3.33

Specified xdebug version for compatibility with php 7.3