### PR TITLE
Fix db seeding special characters like spanish accents

### DIFF
--- a/public/install/database_seeding.php
+++ b/public/install/database_seeding.php
@@ -23,6 +23,7 @@ if (!$mysqli_connection) {
     return;
 }
 
+mysqli_set_charset($mysqli_connection, "utf8");
 $mysqli_select_db = @mysqli_select_db($mysqli_connection, $dbName);
 if (!$mysqli_select_db) {
     echo json_encode(array('success' => false, 'message' => 'Database: ' . $dbName . ' selection failed with error: ' . mysqli_error($mysqli_connection)), true);


### PR DESCRIPTION
Special characters like **ñ** or accents like **é** where insterted in table in wrong format **Ã±** or **Ã©** because of the encoding. Im using a Windows 11, PHP 7.4.16 and mysql 5.7.24.